### PR TITLE
Features/testing dry hack

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -335,6 +335,15 @@ texinfo_documents = [
 # texinfo_no_detailmenu = False
 
 
+autodoc_member_order = 'bysource'
+
+import attr
+
+def process_signature(app, what, name, obj, options, signature,
+            return_annotation):
+    if isinstance(obj, attr._make.Attribute):
+        obj.__class__.__repr__ = lambda *a, **k: None
+
 def maybe_skip_member(app, what, name, obj, skip, options):
     # print (what, name, obj, skip)
     if type(obj) == property:
@@ -344,12 +353,14 @@ def maybe_skip_member(app, what, name, obj, skip, options):
         return False
     whitelisted_init_classes = ["GogsApi", "Token", "UsernamePassword", "Builder"]
     if name == "__init__":
-        return obj.im_class.__name__ not in whitelisted_init_classes
+        if hasattr(obj, 'im_class'):
+            return obj.im_class.__name__ not in whitelisted_init_classes
     blacklisted_names = ["update_kwargs"]
     return skip or (name in blacklisted_names)
 
 def setup(app):
     app.connect('autodoc-skip-member', maybe_skip_member)
+    app.connect('autodoc-process-signature', process_signature)
 
 def add_directive_header(self, sig):
     ModuleLevelDocumenter.add_directive_header(self, sig)

--- a/docs/entities.rst
+++ b/docs/entities.rst
@@ -41,3 +41,9 @@ GogsTeam
 
 .. autoclass:: gogs_client.entities::GogsTeam()
     :members:
+
+GogsEntity
+----------
+
+.. autoclass:: gogs_client.entities::GogsEntity()
+    :members:

--- a/gogs_client/entities.py
+++ b/gogs_client/entities.py
@@ -18,9 +18,22 @@ from collections import OrderedDict
 
 @attr.s
 class GogsEntity(object):
+    """
+    Base class for an entity defined by the API
+
+    """
+
     json = attr.ib()
+    """
+    :ivar json: Contains the json data
+    :vartype: dict
+    """
+
     @classmethod
     def from_json(cls, parsed_json):
+        """
+        Factory function to build an object based on JSON data
+        """
         # with introspection, get arguments of the constructor
         parsed_json['json'] = parsed_json.copy()
         params = cls.__attrs_attrs__
@@ -37,46 +50,38 @@ class GogsEntity(object):
         o = cls(*args, **kwargs)
         return o
 
-
 @attr.s(frozen=True)
 class GogsUser(GogsEntity):
     """
      An immutable representation of a Gogs user
     """
 
-    """
-    The user's id
-
-    :rtype: int
-    """
     id = attr.ib()
+    """
+    The user's id (as *int*)
+    """
     user_id = property(lambda self: self.id)
+    """
+    The user's id (as *int*) - *deprecated*
+    """
 
     """
-    The user's username
-
-    :rtype: str
+    The user's username (as *str*)
     """
     username = attr.ib()
 
     """
-    The user's full name
-
-    :rtype: str
+    The user's full name (as *str*)
     """
     full_name = attr.ib()
 
     """
-    The user's email address. Can be empty as a result of invalid authentication
-
-    :rtype: str
+    The user's email address. Can be empty as a result of invalid authentication (as *str*)
     """
     email = attr.ib(default=None)
 
     """
-    The user's avatar URL
-
-    :rtype: str
+    The user's avatar URL (as *str*)
     """
     avatar_url = attr.ib(default=None)
 
@@ -87,218 +92,182 @@ class GogsRepo(GogsEntity):
     An immutable representation of a Gogs repository
     """
 
-    """
-    The repository's id
-
-    :rtype: int
-    """
     id = attr.ib()
+    """
+    The repository's id (as *int*)
+    """
+
     repo_id = property(lambda self: self.id)
-
     """
-    The owner of the repository
-
-    :rtype: entities.GogsUser
+    The repository's id (as *int*) - *deprecated*
     """
+
     owner = attr.ib(convert=lambda parsed_json:GogsUser.from_json(parsed_json))
-
     """
-    The full name of the repository
-
-    :rtype: str
+    The owner of the repository (as *:obj:`GogsUser`*)
     """
+
     full_name = attr.ib()
-
     """
-    Whether the repository is private
-
-    :rtype: bool
+    The full name of the repository (as *str*)
     """
+
     private = attr.ib()
-
     """
-    Whether the repository is a fork
-
-    :rtype: bool
+    Whether the repository is private (as *bool*)
     """
+
     fork = attr.ib()
-
     """
-    The name of the default branch
-
-    :rtype: str
+    Whether the repository is a fork (as *bool*)
     """
+
     default_branch = attr.ib()
-
     """
-    URLs of the repository
-
-    :rtype: GogsRepo.Urls
+    The name of the default branch (as *str*)
     """
+
     _ssh_url = attr.ib()
     _html_url = attr.ib()
     _clone_url = attr.ib()
     @property
     def urls(self):
+        """
+        URLs of the repository (as *:obj:`GogsRepo.Urls`*)
+        """
         return GogsRepo.Urls(self._html_url, self._clone_url,self._ssh_url)
 
-    """
-    Permissions for the repository
-
-    :rtype: GogsRepo.Permissions
-    """
     permissions = attr.ib(convert=lambda data:GogsRepo.Permissions.from_json(data))
-
     """
-    Gets the repository's parent, when a fork
-
-    :rtype: GogsRepo
+    Permissions for the repository (as *:obj:`GogsRepo.Permissions`*)
     """
+
     parent = attr.ib(convert=lambda data:GogsRepo.from_json(data) if data else None, default=None)
-
     """
-    Whether the repository is empty
-
-    :rtype: bool
+    Gets the repository's parent, when a fork (as *:obj:`GogsRepo`*)
     """
+
     empty = attr.ib(default=None)
-
     """
-    Size of the repository in kilobytes
-
-    :rtype: int
+    Whether the repository is empty (as *bool*)
     """
+
     size = attr.ib(default=None)
+    """
+    Size of the repository in kilobytes (as *int*)
+    """
 
     @attr.s(frozen=True)
     class Urls(object):
         """
-        URL for the repository's webpage
-
-        :rtype: str
+        Class representating the possible URL for a resource
         """
+
         html_url = attr.ib()
-
         """
-        URL for cloning the repository (via HTTP)
-
-        :rtype: str
+        URL for the repository's webpage (as *str*)
         """
+
         clone_url = attr.ib()
-
         """
-        URL for cloning the repository via SSH
-
-        :rtype: str
+        URL for cloning the repository (via HTTP) (as *str*)
         """
+
         ssh_url = attr.ib()
+        """
+        URL for cloning the repository via SSH (as *str*)
+        """
 
     @attr.s(frozen=True)
     class Permissions(GogsEntity):
         """
-        Whether the user that requested this repository has admin permissions
-
-        :rtype: bool
+        Class representating the permession of a resource
         """
         admin = attr.ib(default=False)
-
         """
-        Whether the user that requested this repository has push permissions
-
-        :rtype: bool
+        Whether the user that requested this repository has admin permissions (as *bool*)
         """
+
         push = attr.ib(default=False)
-
         """
-        Whether the user that requested this repository has pull permissions
-
-        :rtype: bool
+        Whether the user that requested this repository has push permissions (as *bool*)
         """
+
         pull = attr.ib(default=False)
+        """
+        Whether the user that requested this repository has pull permissions (as *bool*)
+        """
 
     @attr.s(frozen=True)
     class Hook(GogsEntity):
-        """
-        The hook's id number
-
-        :rtype: int
-        """
         id = attr.ib()
+        """
+        The hook's id number (as *int*)
+        """
         hook_id = property(lambda self: self.id)
-
         """
-        The hook's type (gogs, slack, etc.)
-
-        :rtype: str
+        same as id (as *int*) - *deprecated*
         """
+
         type = attr.ib()
+        """
+        The hook's type (gogs, slack, etc.) (as *str*)
+        """
         hook_type = property(lambda self: self.type)
-
         """
-        The events that fire the hook
-
-        :rtype: List[str]
+        same as type (as *str*) - *deprecated*
         """
+
         events = attr.ib()
-
         """
-        Whether the hook is active
-
-        :rtype: bool
+        The events that fire the hook (as *List[str]*)
         """
+
         active = attr.ib()
-
         """
-        Config of the hook. Possible keys include ``"content_type"``, ``"url"``, ``"secret"``
-
-        :rtype: dict
+        Whether the hook is active (as *bool*)
         """
+
         config = attr.ib()
+        """
+        Config of the hook. Possible keys include ``"content_type"``, ``"url"``, ``"secret"`` (as *dict*)
+        """
 
     @attr.s(frozen=True)
     class DeployKey(GogsEntity):
-        """
-        The key's id number
-
-        :rtype: int
-        """
         id = attr.ib()
+        """
+        The key's id number (as *int*)
+        """
         key_id = property(lambda self: self.id)
-
         """
-        The content of the key
-
-        :rtype: str
+        The key's id number (as *int*)
         """
+
         key = attr.ib()
-
         """
-        URL where the key can be found
-
-        :rtype: str
+        The content of the key (as *str*)
         """
+
         url = attr.ib()
-
         """
-        The name of the key
-
-        :rtype: str
+        URL where the key can be found (as *str*)
         """
+
         title = attr.ib()
-
         """
-        Creation date of the key
-
-        :rtype: str
+        The name of the key (as *str*)
         """
+
         created_at = attr.ib()
-
         """
-        Whether key is read-only
-
-        :rtype: bool
+        Creation date of the key (as *str*)
         """
+
         read_only = attr.ib()
+        """
+        Whether key is read-only (as *bool*)
+        """
 
 
 @attr.s(frozen=True)
@@ -307,55 +276,44 @@ class GogsOrg(GogsEntity):
      An immutable representation of a Gogs Organization
     """
 
-    """
-    The organization's id
-
-    :rtype: int
-    """
     id = attr.ib()
+    """
+    The organization's id (as *int*)
+    """
     org_id = property(lambda self: self.id)
-
     """
-    Organization's username
-
-    :rtype: str
+    same as id (as *int*) - *deprecated*
     """
+
     username = attr.ib()
-
     """
-    Organization's full name
-
-    :rtype: str
+    Organization's username (as *str*)
     """
+
     full_name = attr.ib()
-
     """
-    Organization's avatar url
-
-    :rtype: str
+    Organization's full name (as *str*)
     """
+
     avatar_url = attr.ib()
-
     """
-    Organization's description
-
-    :rtype: str
+    Organization's avatar url (as *str*)
     """
+
     description = attr.ib()
-
     """
-    Organization's website address
-
-    :rtype: str
+    Organization's description (as *str*)
     """
+
     website = attr.ib()
-
     """
-    Organization's location
-
-    :rtype: str
+    Organization's website address (as *str*)
     """
+
     location = attr.ib()
+    """
+    Organization's location (as *str*)
+    """
 
 @attr.s(frozen=True)
 class GogsTeam(GogsEntity):
@@ -363,32 +321,27 @@ class GogsTeam(GogsEntity):
     An immutable representation of a Gogs organization team
     """
 
-    """
-    Team's id
-
-    :rtype: int
-    """
     id = attr.ib()
+    """
+    Team's id (as *int*)
+    """
     team_id = property(lambda self: self.id)
-
     """
-    Team name
-
-    :rtype: str
+    Same as id (as *int*) - *deprecated*
     """
+
     name = attr.ib()
-
     """
-    Description of the team
-
-    :rtype: str
+    Team name (as *str*)
     """
+
     description = attr.ib()
-
     """
-    Team permission, can be read, write or admin, default is read
-
-    :rtype: int
+    Description of the team (as *str*)
     """
+
     permission = attr.ib()
+    """
+    Team permission, can be read, write or admin, default is read (as *int*)
+    """
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 future
 requests
+attrs

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     ],
     keywords=["gogs", "http", "client"],
     packages=find_packages(),
-    install_requires=["future", "requests"],
+    install_requires=["future", "requests", "attrs"],
     test_suite="tests"
 )

--- a/tests/interface_test.py
+++ b/tests/interface_test.py
@@ -344,7 +344,7 @@ class GogsClientInterfaceTest(unittest.TestCase):
             self.assertRegexpMatches(str(data["active"]), r"[tT]rue")
             self.assertRegexpMatches(str(data["admin"]), r"[fF]alse")
             self.assertRegexpMatches(str(data["allow_git_hook"]), r"[fF]alse")
-            self.assertNotIn("source_id", data)
+            self.assertNotIn("id", data)
             self.assertNotIn("location", data)
             self.assertNotIn("allow_import_local", data)
             return 200, {}, self.user_json_str
@@ -585,7 +585,7 @@ class GogsClientInterfaceTest(unittest.TestCase):
         self.assertEqual(request.headers["Authorization"], "Basic {}".format(b64))
 
     def assert_repos_equal(self, repo, expected):
-        self.assertEqual(repo.repo_id, expected.repo_id)
+        self.assertEqual(repo.id, expected.id)
         self.assert_users_equals(repo.owner, expected.owner)
         self.assertEqual(repo.full_name, expected.full_name)
         self.assertEqual(repo.private, expected.private)
@@ -602,7 +602,7 @@ class GogsClientInterfaceTest(unittest.TestCase):
         self.assertEqual(repo.permissions.pull, expected.permissions.pull)
 
     def assert_users_equals(self, user, expected):
-        self.assertEqual(user.user_id, expected.user_id)
+        self.assertEqual(user.id, expected.id)
         self.assertEqual(user.username, expected.username)
         self.assertEqual(user.full_name, expected.full_name)
         self.assertEqual(user.email, expected.email)
@@ -613,14 +613,14 @@ class GogsClientInterfaceTest(unittest.TestCase):
         self.assertEqual(token.token, expected.token)
 
     def assert_hooks_equals(self, hook, expected):
-        self.assertEqual(hook.hook_id, expected.hook_id)
-        self.assertEqual(hook.hook_type, expected.hook_type)
+        self.assertEqual(hook.id, expected.id)
+        self.assertEqual(hook.type, expected.type)
         self.assertEqual(hook.events, expected.events)
         self.assertEqual(hook.config, expected.config)
         self.assertEqual(hook.active, expected.active)
 
     def assert_org_equals(self, org, expected):
-        self.assertEqual(org.org_id, expected.org_id)
+        self.assertEqual(org.id, expected.id)
         self.assertEqual(org.username, expected.username)
         self.assertEqual(org.full_name, expected.full_name)
         self.assertEqual(org.avatar_url, expected.avatar_url)
@@ -629,13 +629,13 @@ class GogsClientInterfaceTest(unittest.TestCase):
         self.assertEqual(org.location, expected.location)
 
     def assert_team_equals(self, team, expected):
-        self.assertEqual(team.team_id, expected.team_id)
+        self.assertEqual(team.id, expected.id)
         self.assertEqual(team.name, expected.name)
         self.assertEqual(team.description, expected.description)
         self.assertEqual(team.permission, expected.permission)
 
     def assert_keys_equals(self, key, expected):
-        self.assertEqual(key.key_id, expected.key_id)
+        self.assertEqual(key.id, expected.id)
         self.assertEqual(key.title, expected.title)
         self.assertEqual(key.url, expected.url)
         self.assertEqual(key.key, expected.key)


### PR DESCRIPTION
just a simple illustration of #10.

it's not perfect: the `name_id` properties had to be changed to `id` and the `hook_type` had to be renamed `type`. That's not great regarding shadowing of globals, but it's ok because in usage they'll always be namespaced.