### PR TITLE
Branches

### DIFF
--- a/gogs_client/__init__.py
+++ b/gogs_client/__init__.py
@@ -1,4 +1,4 @@
 from gogs_client.auth import Authentication, Token, UsernamePassword
-from gogs_client.entities import GogsUser, GogsRepo, GogsOrg, GogsTeam
+from gogs_client.entities import GogsUser, GogsRepo, GogsBranch, GogsCommit, GogsOrg, GogsTeam
 from gogs_client.interface import GogsApi, ApiFailure, NetworkFailure
 from gogs_client.updates import GogsUserUpdate, GogsHookUpdate

--- a/gogs_client/entities.py
+++ b/gogs_client/entities.py
@@ -104,6 +104,11 @@ class GogsRepo(GogsEntity):
     #: :type: entities.GogsUser
     owner = attr.ib(convert=lambda parsed_json: GogsUser.from_json(parsed_json))
 
+    #: The name of the repository
+    #:
+    #: :type: str
+    name = attr.ib()
+
     #: The full name of the repository
     #:
     #: :type: str
@@ -146,6 +151,11 @@ class GogsRepo(GogsEntity):
     #:
     #: :type: GogsRepo
     parent = attr.ib(convert=lambda data: GogsRepo.from_json(data) if data else None, default=None)
+
+    #: The description of the repository
+    #:
+    #: :type: str
+    description = attr.ib(default=None)
 
     #: Whether the repository is empty
     #:

--- a/gogs_client/entities.py
+++ b/gogs_client/entities.py
@@ -274,6 +274,48 @@ class GogsRepo(GogsEntity):
         #: :type: bool
         read_only = attr.ib()
 
+@attr.s(frozen=True)
+class GogsBranch(GogsEntity):
+    """
+    An immutable representation of a Gogs branch
+    """
+
+    #: The branch's name
+    #:
+    #: :type: str
+    name = attr.ib()
+
+    #: The HEAD commit of the branch
+    #:
+    #: :type: entities.GogsCommit
+    commit = attr.ib(convert=lambda parsed_json: GogsCommit.from_json(parsed_json))
+
+@attr.s(frozen=True)
+class GogsCommit(GogsEntity):
+    """
+    An immutable representation of a Gogs commit
+    """
+
+    #: The commit's id
+    #:
+    #: :type: str
+    id = attr.ib()
+
+    #: The commit's message
+    #:
+    #: :type: str
+    message = attr.ib()
+
+    #: The commit's url
+    #:
+    #: :type: str
+    url = attr.ib()
+
+    #: The commit's timestamp
+    #:
+    #: :type: str
+    timestamp = attr.ib()
+
 
 @attr.s(frozen=True)
 class GogsOrg(GogsEntity):

--- a/gogs_client/interface.py
+++ b/gogs_client/interface.py
@@ -194,6 +194,24 @@ class GogsApi(object):
         response = self._check_ok(self._get(path, auth=auth))
         return [GogsRepo.from_json(repo_json) for repo_json in response.json()]
 
+    def get_branch(self, auth, username, repo_name, branch_name):
+        """
+        Returns the branch with name ``branch_name`` in the repository with name ``repo_name``
+        owned by the user with username ``username``.
+        
+        :param auth.Authentication auth: authentication object 
+        :param str username: username of owner of repository containing the branch
+        :param str repo_name: name of the repository with the branch
+        :param str branch_name: name of the branch to return
+        :return a branch
+        :rtype: GogsBranch
+        :raises NetworkFailure: if there is an error communicating with the server
+        :raises ApiFailure: if the request cannot be serviced
+        """
+        path = "/repos/{u}/{r}/branches/{b}".format(u=username, r=repo_name, b=branch_name)
+        response = self._check_ok(self._get(path, auth=auth))
+        return GogsBranch.from_json(response.json())
+
     def delete_repo(self, auth, username, repo_name):
         """
         Deletes the repository with name ``repo_name`` owned by the user with username ``username``.

--- a/gogs_client/interface.py
+++ b/gogs_client/interface.py
@@ -2,7 +2,7 @@ import requests
 
 from gogs_client._implementation.http_utils import RelativeHttpRequestor, append_url
 from gogs_client.auth import Token
-from gogs_client.entities import GogsUser, GogsRepo, GogsOrg, GogsTeam
+from gogs_client.entities import GogsUser, GogsRepo, GogsBranch, GogsOrg, GogsTeam
 
 
 class GogsApi(object):
@@ -211,6 +211,22 @@ class GogsApi(object):
         path = "/repos/{u}/{r}/branches/{b}".format(u=username, r=repo_name, b=branch_name)
         response = self._check_ok(self._get(path, auth=auth))
         return GogsBranch.from_json(response.json())
+
+    def get_branches(self, auth, username, repo_name):
+        """
+        Returns the branches in the repository with name ``repo_name`` owned by the user with username ``username``.
+
+        :param auth.Authentication auth: authentication object 
+        :param str username: username of owner of repository containing the branch
+        :param str repo_name: name of the repository with the branch
+        :return a list of branches
+        :rtype: List[GogsBranch]
+        :raises NetworkFailure: if there is an error communicating with the server
+        :raises ApiFailure: if the request cannot be serviced
+        """
+        path = "/repos/{u}/{r}/branches".format(u=username, r=repo_name)
+        response = self._check_ok(self._get(path, auth=auth))
+        return [GogsBranch.from_json(branch_json) for branch_json in response.json()]
 
     def delete_repo(self, auth, username, repo_name):
         """

--- a/tests/interface_test.py
+++ b/tests/interface_test.py
@@ -23,7 +23,9 @@ class GogsClientInterfaceTest(unittest.TestCase):
                     "email": "u@gogs.io",
                     "avatar_url": "/avatars/1"
                   },
+                  "name": "Hello-World",
                   "full_name": "unknwon/Hello-World",
+                  "description": "Some description",
                   "private": false,
                   "fork": false,
                   "parent": null,
@@ -48,7 +50,9 @@ class GogsClientInterfaceTest(unittest.TestCase):
                     "email": "u@gogs.io",
                     "avatar_url": "/avatars/1"
                   },
+                  "name": "Hello-World",
                   "full_name": "unknwon/Hello-World",
+                  "description": "Some description",
                   "private": false,
                   "fork": false,
                   "parent": null,
@@ -72,6 +76,7 @@ class GogsClientInterfaceTest(unittest.TestCase):
                     "email": "u@gogs.io",
                     "avatar_url": "/avatars/1"
                   },
+                  "name": "Hello-World-Again",
                   "full_name": "unknwon/Hello-World-Again",
                   "private": false,
                   "fork": false,

--- a/tests/interface_test.py
+++ b/tests/interface_test.py
@@ -39,31 +39,6 @@ class GogsClientInterfaceTest(unittest.TestCase):
                     "pull": true
                   }
                 }"""
-        self.branch_json_str = """{
-                "name": "master",
-                "commit": {
-                    "id": "c17825309a0d52201e78a19f49948bcc89e52488",
-                    "message": "migrated to RC0.2\n",
-                    "url": "Not implemented",
-                    "author": {
-                        "name": "Joel Lonbeck",
-                        "email": "joel@neutrinographics.com",
-                        "username": "joel"
-                    },
-                    "committer": {
-                        "name": "Joel Lonbeck",
-                        "email": "joel@neutrinographics.com",
-                        "username": "joel"
-                    },
-                    "verification": {
-                        "verified": false,
-                        "reason": "gpg.error.not_signed_commit",
-                        "signature": "",
-                        "payload": ""
-                    },
-                    "timestamp": "2017-05-17T21:11:25Z"
-                    }
-                }"""
         self.repos_list_json_str = """[{
                 "id": 27,
                 "owner": {
@@ -113,6 +88,80 @@ class GogsClientInterfaceTest(unittest.TestCase):
                     "pull": true
                   }
                 }]"""
+        self.branch_json_str = """{
+                        "name": "master",
+                        "commit": {
+                            "id": "c17825309a0d52201e78a19f49948bcc89e52488",
+                            "message": "migrated to RC0.2",
+                            "url": "Not implemented",
+                            "author": {
+                                "name": "Joel Lonbeck",
+                                "email": "joel@neutrinographics.com",
+                                "username": "joel"
+                            },
+                            "committer": {
+                                "name": "Joel Lonbeck",
+                                "email": "joel@neutrinographics.com",
+                                "username": "joel"
+                            },
+                            "verification": {
+                                "verified": false,
+                                "reason": "gpg.error.not_signed_commit",
+                                "signature": "",
+                                "payload": ""
+                            },
+                            "timestamp": "2017-05-17T21:11:25Z"
+                            }
+                        }"""
+        self.branches_list_json_str = """[{
+                        "name": "master",
+                        "commit": {
+                            "id": "c17825309a0d52201e78a19f49948bcc89e52488",
+                            "message": "migrated to RC0.2",
+                            "url": "Not implemented",
+                            "author": {
+                                "name": "Joel Lonbeck",
+                                "email": "joel@neutrinographics.com",
+                                "username": "joel"
+                            },
+                            "committer": {
+                                "name": "Joel Lonbeck",
+                                "email": "joel@neutrinographics.com",
+                                "username": "joel"
+                            },
+                            "verification": {
+                                "verified": false,
+                                "reason": "gpg.error.not_signed_commit",
+                                "signature": "",
+                                "payload": ""
+                            },
+                            "timestamp": "2017-05-17T21:11:25Z"
+                            }
+                        },{
+                        "name": "develop",
+                        "commit": {
+                            "id": "r03kd7cjr9a0d52201e78a19f49948bcc89e52488",
+                            "message": "another branch",
+                            "url": "Not implemented",
+                            "author": {
+                                "name": "Joel Lonbeck",
+                                "email": "joel@neutrinographics.com",
+                                "username": "joel"
+                            },
+                            "committer": {
+                                "name": "Joel Lonbeck",
+                                "email": "joel@neutrinographics.com",
+                                "username": "joel"
+                            },
+                            "verification": {
+                                "verified": false,
+                                "reason": "gpg.error.not_signed_commit",
+                                "signature": "",
+                                "payload": ""
+                            },
+                            "timestamp": "2017-05-17T21:11:25Z"
+                            }
+                        }]"""
         self.user_json_str = """{
                   "id": 1,
                   "username": "unknwon",
@@ -262,14 +311,6 @@ class GogsClientInterfaceTest(unittest.TestCase):
         self.assertEqual(last_call.request.url, self.path_with_token(uri2))
 
     @responses.activate
-    def test_get_branch1(self):
-        uri = self.path("/repos/username/repo/branches/branch")
-        responses.add(responses.GET, uri, body=self.branch_json_str, status=200)
-        branch = self.client.get_branch(self.token, "username", "branch")
-        self.assert_branches_equal(branch, self.expected_branch)
-
-
-    @responses.activate
     def test_get_user_repos(self):
         uri = self.path("/users/username/repos")
         responses.add(responses.GET, uri, body=self.repos_list_json_str, status=200)
@@ -291,6 +332,21 @@ class GogsClientInterfaceTest(unittest.TestCase):
         self.assertEqual(first_call.request.url, self.path_with_token(uri1))
         last_call = responses.calls[1]
         self.assertEqual(last_call.request.url, self.path_with_token(uri2))
+
+    @responses.activate
+    def test_get_branch(self):
+        uri = self.path("/repos/username/repo/branches/branch")
+        responses.add(responses.GET, uri, body=self.branch_json_str, status=200)
+        branch = self.client.get_branch(self.token, "username", "repo", "branch")
+        self.assert_branches_equal(branch, self.expected_branch)
+
+    @responses.activate
+    def test_get_branches(self):
+        uri = self.path("/repos/username/repo/branches")
+        responses.add(responses.GET, uri, body=self.branches_list_json_str, status=200)
+        branches = self.client.get_branches(self.token, "username", "repo")
+        self.assertEqual(len(branches), 2)
+        self.assert_branches_equal(branches[0], self.expected_branch)
 
     @responses.activate
     def test_create_user1(self):

--- a/tests/interface_test.py
+++ b/tests/interface_test.py
@@ -39,6 +39,31 @@ class GogsClientInterfaceTest(unittest.TestCase):
                     "pull": true
                   }
                 }"""
+        self.branch_json_str = """{
+                "name": "master",
+                "commit": {
+                    "id": "c17825309a0d52201e78a19f49948bcc89e52488",
+                    "message": "migrated to RC0.2\n",
+                    "url": "Not implemented",
+                    "author": {
+                        "name": "Joel Lonbeck",
+                        "email": "joel@neutrinographics.com",
+                        "username": "joel"
+                    },
+                    "committer": {
+                        "name": "Joel Lonbeck",
+                        "email": "joel@neutrinographics.com",
+                        "username": "joel"
+                    },
+                    "verification": {
+                        "verified": false,
+                        "reason": "gpg.error.not_signed_commit",
+                        "signature": "",
+                        "payload": ""
+                    },
+                    "timestamp": "2017-05-17T21:11:25Z"
+                    }
+                }"""
         self.repos_list_json_str = """[{
                 "id": 27,
                 "owner": {
@@ -188,6 +213,7 @@ class GogsClientInterfaceTest(unittest.TestCase):
               "read_only": true
             }]"""
         self.expected_repo = gogs_client.GogsRepo.from_json(json.loads(self.repo_json_str))
+        self.expected_branch = gogs_client.GogsBranch.from_json(json.loads(self.branch_json_str))
         self.expected_user = gogs_client.GogsUser.from_json(json.loads(self.user_json_str))
         self.expected_hook = gogs_client.GogsRepo.Hook.from_json(json.loads(self.hook_json_str))
         self.expected_org = gogs_client.GogsOrg.from_json(json.loads(self.org_json_str))
@@ -234,6 +260,14 @@ class GogsClientInterfaceTest(unittest.TestCase):
         self.assertEqual(first_call.request.url, self.path_with_token(uri1))
         last_call = responses.calls[1]
         self.assertEqual(last_call.request.url, self.path_with_token(uri2))
+
+    @responses.activate
+    def test_get_branch1(self):
+        uri = self.path("/repos/username/repo/branches/branch")
+        responses.add(responses.GET, uri, body=self.branch_json_str, status=200)
+        branch = self.client.get_branch(self.token, "username", "branch")
+        self.assert_branches_equal(branch, self.expected_branch)
+
 
     @responses.activate
     def test_get_user_repos(self):
@@ -600,6 +634,16 @@ class GogsClientInterfaceTest(unittest.TestCase):
         self.assertEqual(repo.permissions.admin, expected.permissions.admin)
         self.assertEqual(repo.permissions.push, expected.permissions.push)
         self.assertEqual(repo.permissions.pull, expected.permissions.pull)
+
+    def assert_branches_equal(self, branch, expected):
+        self.assertEqual(branch.name, expected.name)
+        self.assert_commits_equal(branch.commit, expected.commit)
+
+    def assert_commits_equal(self, commit, expected):
+        self.assertEqual(commit.id, expected.id)
+        self.assertEqual(commit.message, expected.message)
+        self.assertEqual(commit.url, expected.url)
+        self.assertEqual(commit.timestamp, expected.timestamp)
 
     def assert_users_equals(self, user, expected):
         self.assertEqual(user.id, expected.id)


### PR DESCRIPTION
This PR primarily updates the interface to support retrieving branches. These additions are needed for use in https://github.com/unfoldingWord-dev/d43-catalog.

new interface methods:
* `get_branch(self, auth, username, repo_name, branch_name)`
* `get_branches(self, auth, username, repo_name)`

new entities:
* `GogsBranch`
* `GogsCommit`

Also added two new properties to the `GogsRepo` entity:
* `name` required
* `description` optional